### PR TITLE
Better GitHub API request error handling

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,8 +57,9 @@
     headers:
       Content-Type: "application/json"
       Authorization: "token {{ GITHUB_ACCESS_TOKEN }}"
-  register: task_log
-  failed_when: task_log.content.find('key is already in use') == 0
+    status_code:
+    - 201
+    - 422
 
 - name: Configure SSH agent and clone repository
   block:


### PR DESCRIPTION
Thanks for the blog on IBM community, I'm using your method in my own project :smile:

However we can improve the error handling in the "Add SSH public key to GitHub account" step using HTTP response status codes:

- `201`: Created
- `422`: Key is already in use

Also we just need **admin:public_key** when generate new token for this purpose.